### PR TITLE
Add functionality for both Remote servers and Localhost

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ npx spotify-auth-token@latest --clientId f40c6b --clientSecret 0199f38a --uri 80
 With short flags:
 
 ```bash
-npx spotify-auth-token@latest -ci f40c6b -cs 0199f38a -p 8000 -s "user-library-read user-top-read"
+npx spotify-auth-token@latest -ci f40c6b -cs 0199f38a -u 8000 -s "user-library-read user-top-read"
 ```
 
 ### Options
@@ -55,7 +55,7 @@ npx spotify-auth-token@latest -ci f40c6b -cs 0199f38a -p 8000 -s "user-library-r
 | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `-ci` \| `--clientId`     | ✅ Spotify client id                                                                                                                                           |
 | `-cs` \| `--clientSecret` | ✅ Spotify client secret                                                                                                                                       |
-| `-p` \| `--port`          | ❌ Port for localhost redirect url. Default: `3000`                                                                                                            |
+| `-u` \| `--port`          | ❌ Redirect url. Default: `https://localhost:3000`                                                                                                            |
 | `-s` \| `--scopes`        | ❌ [Spotify auth scopes](https://developer.spotify.com/documentation/general/guides/authorization/scopes/), separated by a space. Default: `'user-read-email'` |
 | `-o` \| `--outDir`        | ❌ Custom output directory relative to the current directory                                                                                                   |
 | `-f` \| `--fileName`      | ❌ Custom file name for the token                                                                                                                              |
@@ -102,7 +102,7 @@ const { authorize } = require('spotify-auth-token/dist/authorize');
 const token = await authorize({
   clientId: 'clientId',
   clientSecret: 'clientSecret',
-  port: 3000,
+  uri: "http://localhost:3000",
   scopes: 'user-read-email user-top-read',
   noEmit: true,
 });
@@ -116,7 +116,7 @@ import authorize from 'spotify-auth-token';
 const token = await authorize({
   clientId: 'clientId',
   clientSecret: 'clientSecret',
-  port: 3000,
+  uri: "http://localhost:3000",
   scopes: 'user-read-email user-top-read',
 });
 ```
@@ -129,7 +129,7 @@ import authorize, { UserConfig } from 'spotify-auth-token';
 const config: UserConfig = {
   clientId: 'clientId',
   clientSecret: 'clientSecret',
-  port: 3000,
+  uri: "http://localhost:3000",
   scopes: 'user-read-email user-top-read',
 };
 

--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ npx spotify-auth-token@latest -ci f40c6b -cs 0199f38a -u 8000 -s "user-library-r
 | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `-ci` \| `--clientId`     | ✅ Spotify client id                                                                                                                                           |
 | `-cs` \| `--clientSecret` | ✅ Spotify client secret                                                                                                                                       |
-| `-u` \| `--port`          | ❌ Redirect url. Default: `https://localhost:3000`                                                                                                            |
+| `-u` \| `--uri`          | ❌ Redirect url. Default: `https://localhost:3000`                                                                                                            |
 | `-s` \| `--scopes`        | ❌ [Spotify auth scopes](https://developer.spotify.com/documentation/general/guides/authorization/scopes/), separated by a space. Default: `'user-read-email'` |
 | `-o` \| `--outDir`        | ❌ Custom output directory relative to the current directory                                                                                                   |
 | `-f` \| `--fileName`      | ❌ Custom file name for the token                                                                                                                              |

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ npx spotify-auth-token@latest --clientId f40c6b --clientSecret 0199f38a
 Optional arguments example:
 
 ```bash
-npx spotify-auth-token@latest --clientId f40c6b --clientSecret 0199f38a --port 8000 --scopes "user-library-read"
+npx spotify-auth-token@latest --clientId f40c6b --clientSecret 0199f38a --uri 8000 --scopes "user-library-read"
 ```
 
 With short flags:

--- a/src/authorize.ts
+++ b/src/authorize.ts
@@ -10,7 +10,7 @@ export const authorize: AuthFunction = async (userConfig) => {
       ? await configParser(userConfig)
       : await configParser(process.argv.slice(2));
 
-    const redirectUri = `http://localhost:${config.port}`;
+    const redirectUri = config.uri;
     const state = id();
 
     const spotifyUrl =
@@ -26,8 +26,18 @@ export const authorize: AuthFunction = async (userConfig) => {
 
     console.info('Please click the link to login to Spotify in the browser\n');
     console.info(spotifyUrl + '\n');
-
-    const authUrl = await getLocalhostUrl(config.port);
+    if(config.uri.includes("localhost")) {
+      let port = config.uri.split(":")[1];
+    }
+    else {
+      if (!(config.uri.includes("https://") || config.uri.includes("http://"))){
+        let port = new URL(`http://${config.uri}`).port
+      }
+      else {
+        let port = new URL(config.uri).port
+      }
+    }
+    const authUrl = await getLocalhostUrl(port);
     const params = new URLSearchParams(authUrl);
     const receivedCode = params.get('code');
     const receivedState = params.get('state');

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ import { AppConfig } from './types';
 export const defaultConfig: AppConfig = {
   clientId: '',
   clientSecret: '',
-  port: 3000,
+  uri: 'http://localhost:3000',
   noEmit: false,
   outDir: '',
   fileName: 'spotify-token',
@@ -23,11 +23,16 @@ export const configParser = parserFactory(defaultConfig, {
       errorMessage:
         'Please specify your Spotify client secret.\nFor more info, visit https://github.com/eegli/spotify-auth-token',
     },
+    {
+      argName:'uri',
+      errorMessage:
+        'Please specify your Spotify redirect URL specified in the developer portal.\n For more info, visit https://github.com/eegli/spotify-auth-token'
+    }
   ],
   shortFlags: {
     '-ci': 'clientId',
     '-cs': 'clientSecret',
-    '-p': 'port',
+    '-u': 'uri',
     '-o': 'outDir',
     '-f': 'fileName',
     '-s': 'scopes',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,4 @@
 type OptionalConfig = {
-  port: number;
   scopes: string;
   fileName: string;
   outDir: string;
@@ -9,6 +8,7 @@ type OptionalConfig = {
 type RequiredConfig = {
   clientId: string;
   clientSecret: string;
+  uri:string;
 };
 
 export type AuthFunction<T extends UserConfig = UserConfig> = (


### PR DESCRIPTION
### Description of Changes

Previously, this package has only been able to be used locally, within localhost specifically.
With this PR, I have changed the port parameter to a URI parameter and made it required, that way cloud/remote server instances such as Heroku can still gain an access token.
